### PR TITLE
MNT: Suppress pytest warning

### DIFF
--- a/pytest_astropy_header/display.py
+++ b/pytest_astropy_header/display.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This plugin provides customization of the header displayed by pytest for
-reporting purposes.
+reporting purposes. PYTEST_DONT_REWRITE
 """
 
 import os

--- a/pytest_astropy_header/display.py
+++ b/pytest_astropy_header/display.py
@@ -1,14 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This plugin provides customization of the header displayed by pytest for
-reporting purposes. PYTEST_DONT_REWRITE
-"""
+reporting purposes.
 
+PYTEST_DONT_REWRITE
+
+"""
 import os
 import sys
 import datetime
 import locale
-import math
 from collections import OrderedDict
 from distutils.version import LooseVersion
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,6 @@ test =
 [options.entry_points]
 pytest11 =
     pytest_astropy_header = pytest_astropy_header.display
+
+[flake8]
+max-line-length = 125


### PR DESCRIPTION
Port over astropy/astropy#9437 by @jdavies-st, as suggested by @bsipocz .

Tests will probably fail because #2 is unresolved.

Fixes #3