### PR TITLE
Fix PytestAssertRewriteWarning

### DIFF
--- a/pytest_astropy_header/display.py
+++ b/pytest_astropy_header/display.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This plugin provides customization of the header displayed by pytest for
-reporting purposes.
+reporting purposes. PYTEST_DONT_REWRITE
 """
 
 import os


### PR DESCRIPTION
Fixes the warning message:
```
.../_pytest/config/__init__.py:545
.../_pytest/config/__init__.py:545: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: astropy.tests.plugins.display
    self.import_plugin(import_spec)
```