### PR TITLE
BUG: TESTED_VERSIONS undefined without astropy installed

### DIFF
--- a/pytest_astropy_header/display.py
+++ b/pytest_astropy_header/display.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
 
     ASTROPY_INSTALLED = False
+    TESTED_VERSIONS = OrderedDict()
 
 else:
 


### PR DESCRIPTION
When a package that does not depend on astropy uses this plugin, you get:

```
ImportError: cannot import name 'TESTED_VERSIONS' from 'pytest_astropy_header.display'
```