### PR TITLE
Add a note to the user guide in the README about adding a custom footer to the header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,17 @@ be compatible with different astropy versions is via the ``conftest.py`` file::
 The key to ``PYTEST_HEADER_MODULES`` should be the name that will be displayed
 in the header, and the value should be the name of the Python module.
 
+If you would like to append other text to the end of the header, you can do this
+by implementing your own ``pytest_report_header()`` function in the
+``conftest.py`` file in your package. For example, to add a custom footer to the
+end of the Astropy header, you could define::
+
+    def pytest_report_header(config):
+        footer = ("This is some custom text that will appear after the "
+                  "Astropy pytest header!")
+        return hdr + "\n"
+
+
 Migrating from the astropy header plugin to pytest-astropy
 ----------------------------------------------------------
 


### PR DESCRIPTION
I wanted to add some custom text to the bottom of the Astropy header for tests run in a package I maintain that uses the package template. It took me some digging to figure out how to do this, so I thought it might make sense to document it somewhere?