### PR TITLE
Use OpenAstronomy/build-python-dist to simplify publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,34 +11,13 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
-
     steps:
-    - uses: actions/checkout@v2
+    - id: build
+      uses: OpenAstronomy/build-python-dist@v1
       with:
-        fetch-depth: 0
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: Install python-build and twine
-      run: python -m pip install pip build "twine>=3.3" -U
-
-    - name: Build package
-      run: python -m build --sdist --wheel .
-
-    - name: List result
-      run: ls -l dist
-
-    - name: Check wheel
-      run: python -m twine check --strict dist/*
-
-    - name: Test package
-      run: |
-        cd ..
-        python -m venv testenv
-        testenv/bin/pip install astropy pytest pytest-astropy-header/dist/*.whl
-        testenv/bin/pytest pytest-astropy-header/tests
-
+        pure_python_wheel: true
+        test_extras: test
+        test_command: pytest ${{ github.workspace }}/tests
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,11 @@ on:
       - '*'
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-latest
+  publish:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
     if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
-    steps:
-    - id: build
-      uses: OpenAstronomy/build-python-dist@v1
-      with:
-        pure_python_wheel: true
-        test_extras: test
-        test_command: pytest ${{ github.workspace }}/tests
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+    with:
+      test_extras: test
+      test_command: pytest $GITHUB_WORKSPACE/tests
+    secrets:
+      pypi_password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
We've been writing an action (https://github.com/OpenAstronomy/build-python-dist) over at OpenAstronomy to try and simplify the boilerplate of building source distributions, as well as wheels for pure Python packages. This is a test to see if it all works properly in the wild.

We are also working on a reusable workflow that will combine the build and publish step, which would simplify things even further, but I thought I'd first try this since it is already an improvement.