### PR TITLE
Rename token option

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,4 +14,4 @@ jobs:
       test_extras: test
       test_command: pytest $GITHUB_WORKSPACE/tests
     secrets:
-      pypi_password: ${{ secrets.PYPI_API_TOKEN }}
+      pypi_token: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
We renamed the pypi_password option to pypi_token.