### PR TITLE
Use stable tag for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@main
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
     with:
       test_extras: test


### PR DESCRIPTION
This now adjusts the publish workflow to use the v1 stable tag for the publish workflow.

In principle we could also make it so that the publish workflow only runs if all the other jobs pass successfully - is that something we might want?