### PR TITLE
Use OpenAstronomy tox workflow

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -9,48 +9,15 @@ on:
 
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest46
-          - os: windows-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest50
-          - os: macos-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest51
-          - os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest52
-          - os: windows-latest
-            python-version: 3.9
-            toxenv: py39-test-pytest53
-          - os: macos-latest
-            python-version: 3.9
-            toxenv: py39-test-pytest60
-          - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-pytest61
-          - os: windows-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest62
-          - os: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytestdev
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install tox
-      run: python -m pip install tox
-    - name: Run tox
-      run: tox -v -e ${{ matrix.toxenv }}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - linux: py37-test-pytest46
+        - windows: py37-test-pytest50
+        - macos: py38-test-pytest51
+        - linux: py38-test-pytest52
+        - windows: py39-test-pytest53
+        - macos: py39-test-pytest60
+        - linux: py39-test-pytest61
+        - windows: py310-test-pytest62
+        - linux: py310-test-pytestdev


### PR DESCRIPTION
We don't necessarily have to use this, but this is just to demonstrate how we could use the tox workflow from OpenAstronomy (from https://github.com/OpenAstronomy/github-actions-workflows) to reduce the amount of boilerplate configuration.