### PR TITLE
Make the plugin aware of `run-slow` and `run-hugemem`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.2.2 (unreleased)
 ==================
 
+- The plugin is now aware of the ``run_slow`` and ``run_hugemem`` options
+  introduced in ``pytest-astropy`` version 0.10.0. [#48]
+
 0.2.1 (2022-03-09)
 ==================
 

--- a/pytest_astropy_header/display.py
+++ b/pytest_astropy_header/display.py
@@ -120,9 +120,8 @@ def pytest_report_header(config):
 
     s += "\n"
 
-    special_opts = ["remote_data", "pep8"]
     opts = []
-    for op in special_opts:
+    for op in ("remote_data", "pep8", "run_slow", "run_hugemem"):
         op_value = getattr(config.option, op, None)
         if op_value:
             if isinstance(op_value, str):


### PR DESCRIPTION
The `run-slow` and `run-hugemem` options are available since `pytest-astropy` 0.10.0 (astropy/pytest-astropy#48). This plugin now modifies the test output header appropriately if they are used.

I would have modified the relevant tests, but there don't seem to be any.

I also noticed the `pep8` option,  but I don't understand why it is listed, so in the absence of tests I don't dare to remove it.